### PR TITLE
[extra-cmake-modules] Update to upstream 5.85.0.

### DIFF
--- a/rpm/extra-cmake-modules.spec
+++ b/rpm/extra-cmake-modules.spec
@@ -1,5 +1,5 @@
 Name:        extra-cmake-modules
-Version:     5.75.0
+Version:     5.85.0
 Release:     1
 Summary:     The Extra CMake Modules package
 License:     BSD


### PR DESCRIPTION
KCalendarCore is now using features from ecm 5.80. This has been reverted in a patch, but updating ecm would be a better long term solution.

@pvuorela don't hesitate to ping other reviewers as well.