### PR TITLE
[extra-cmake-modules] Update to upstream 5.90.

### DIFF
--- a/rpm/extra-cmake-modules.spec
+++ b/rpm/extra-cmake-modules.spec
@@ -1,5 +1,5 @@
 Name:        extra-cmake-modules
-Version:     5.85.0
+Version:     5.90.0
 Release:     1
 Summary:     The Extra CMake Modules package
 License:     BSD
@@ -22,9 +22,6 @@ files to perform common tasks and toolchain files that must be specified on the 
 
 %install
 %make_install
-
-%post -p /sbin/ldconfig
-%postun -p /sbin/ldconfig
 
 %files
 %license COPYING-CMAKE-SCRIPTS


### PR DESCRIPTION
This update would simplify the patching to be done to the `CMakeList.txt` when we will update KCalendarCore to latest upstream.

@pvuorela, what do you think ? Notice also that I removed the `ldconfig` on post and postun because this is a noarch package with not any compiled library, so I don't think there is any need to refresh the loader cache, if I'm right. Do you think it's correct ?