### PR TITLE
[extra-cmake-modules] Update to upstream 5.99.

### DIFF
--- a/rpm/extra-cmake-modules.spec
+++ b/rpm/extra-cmake-modules.spec
@@ -1,5 +1,5 @@
 Name:        extra-cmake-modules
-Version:     5.90.0
+Version:     5.99.0
 Release:     1
 Summary:     The Extra CMake Modules package
 License:     BSD


### PR DESCRIPTION
@pvuorela, this update will be necessary to update KCalendarCore since they are using a new macro in their CMakeList.txt, see https://api.kde.org/ecm/module/ECMDeprecationSettings.html#module:ECMDeprecationSettings (added in 5.91). This is not in a hurry though.